### PR TITLE
Fix: Remove unused React import to enable successful CI/CD build

### DIFF
--- a/src/features/alerts/CriticalAlerts.tsx
+++ b/src/features/alerts/CriticalAlerts.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Alerts from './Alerts';
 
 const CriticalAlerts = () => {


### PR DESCRIPTION
This PR removes an unused React import in CriticalAlerts.tsx, fixing the build error during GitHub Actions deploy.